### PR TITLE
Fixed TypeError with Jimp

### DIFF
--- a/packer/index.js
+++ b/packer/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const Jimp = require('jimp');
+const { Jimp } = require('jimp');
 const playwright = require('playwright');
 const minimist = require('minimist');
 require('node-zip');


### PR DESCRIPTION
Fixed an issue with the packer's index.JS using old import method (TypeError Jimp.read)
`const Jimp = require('jimp');` instead of `const { Jimp } = require('jimp');`